### PR TITLE
Fix V3005

### DIFF
--- a/RPG Paper Maker/Engine/Forms/DialogEvent/DialogEvent.cs
+++ b/RPG Paper Maker/Engine/Forms/DialogEvent/DialogEvent.cs
@@ -618,7 +618,7 @@ namespace RPG_Paper_Maker
         private void CommandUnderscoreTimer_Tick(object sender, EventArgs e)
         {
             if (!IsUnderScoreDisplayed) CommandsView.SelectedNode.Text = WANOK.ListBeginning + CurrentMethodString + "_";
-            else CommandsView.SelectedNode.Text = CommandsView.SelectedNode.Text = WANOK.ListBeginning + CurrentMethodString;
+            else CommandsView.SelectedNode.Text = WANOK.ListBeginning + CurrentMethodString;
             IsUnderScoreDisplayed = !IsUnderScoreDisplayed;
         }
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

-  The 'CommandsView.SelectedNode.Text' variable is assigned to itself. RPG Paper Maker DialogEvent.cs 621